### PR TITLE
Fix the dockerfile and update a few more features

### DIFF
--- a/aks-cli/helpers/current.ps1
+++ b/aks-cli/helpers/current.ps1
@@ -83,7 +83,7 @@ function SwitchCurrentCluster([switch] $clear, [switch] $refresh)
 
     $global:GlobalCurrentCluster = ClusterMenu -refresh $refresh
 
-    AzAksCurrentCommand 'get-credentials -a --overwrite-existing > $1'
+    AzAksCurrentCommand 'get-credentials --overwrite-existing > $1'
 
     UpdateShellWindowTitle
     

--- a/aks-cli/init.ps1
+++ b/aks-cli/init.ps1
@@ -1,3 +1,4 @@
+az config set core.login_experience_v2=off
 Clear-Host
 az login --use-device-code -o none
 


### PR DESCRIPTION
Changes to the dockerfile:
* The newest alpine image of the AZ CLI is missing many packages needed to install powershell core in the container
* The powershell alpine binaries are now called linux-musl instead of linux-alpine
* The kubectl cert-manager plugin is now called cmctl and is hosted seperatly from the cert-manager binaries
* The stern github project has changed names and release naming conventions
* k9s and popeye has also done minor naming changes
* Add the Flux CLI for gitops development and add it to bash completion
* According to the documentation the install url for the linkerd CLI is now install-edge (https://linkerd.io/2.15/getting-started/)
* Update the URL for the droid sans mono font

Changes to init.ps1
* Since [Az CLI 2.61.0](https://learn.microsoft.com/en-us/cli/azure/authenticate-azure-cli-interactively#subscription-selector) there is an interactive subscription selector when you use the interactive login, this gives a bad developer UX since you end up selecting subscription twice. The command "az config set core.login_experience_v2=off" disables this first subscription selector

Changes to current.ps1
* Always trying to get cluster administrator credentials causes issues when connection to clusters that have disabled local accounts, switch to just using normal cluster user credentials.